### PR TITLE
Only wrap View classes if they've actually classes.

### DIFF
--- a/flask_injector.py
+++ b/flask_injector.py
@@ -40,7 +40,7 @@ def wrap_fun(fun, injector):
             return fun(*args, **dict(injections, **kwargs))
 
         return wrapper
-    elif hasattr(fun, 'view_class'):
+    elif hasattr(fun, 'view_class') and isinstance(fun.view_class, type):
         current_class = fun.view_class
 
         def cls(**kwargs):


### PR DESCRIPTION
This should resolve #6 by making sure that fun.view_class is a type that we can create an instance of.
