### PR TITLE
Bug fix of memory leak of GreenThread objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - INJECTOR_VERSION="==0.9.0"
   - INJECTOR_VERSION=""
 install:
-  - pip install flake8 nose==1.3.0 flask==0.10.1 flask_restful injector$INJECTOR_VERSION flask_cache flask_sqlalchemy
+  - pip install flake8 nose==1.3.0 flask==0.10.1 flask_restful injector$INJECTOR_VERSION flask_cache flask_sqlalchemy eventlet
 script:
   - flake8 --max-line-length=110 *.py
   - nosetests -v


### PR DESCRIPTION
* This problem manifests when eventlet is enabled, the RequestScope doesn't
  release reference to GreenThread objects, which causes memory leak