### PR TITLE
Fixed class_args key error

### DIFF
--- a/flask_injector.py
+++ b/flask_injector.py
@@ -75,7 +75,7 @@ def wrap_class_based_view(fun, injector):
         # if the lines above succeeded we're quite sure it's flask_restful resource
     else:
         flask_restful_api = None
-        class_args = fun_closure['class_args']
+        class_args = fun_closure.get('class_args')
         assert not class_args, 'Class args are not supported, use kwargs instead'
 
     if (


### PR DESCRIPTION
Fix for https://github.com/alecthomas/flask_injector/issues/14. This uses the `dict.get()` method so that we won't get a KeyError if `fun_closure` doesn't have a `class_args` key since class_args aren't supported anyway.