### PR TITLE
Support Flask 0.11

### DIFF
--- a/flask_injector.py
+++ b/flask_injector.py
@@ -326,7 +326,16 @@ def process_error_handler_spec(spec, injector):
         except KeyError:
             pass
         else:
-            custom_handlers[:] = [(error, wrap_fun(fun, injector)) for (error, fun) in custom_handlers]
+            if isinstance(custom_handlers, list):  # Flask < 0.11
+                custom_handlers[:] = [
+                    (error, wrap_fun(fun, injector))
+                    for (error, fun) in custom_handlers
+                ]
+            else:
+                custom_handlers = {
+                    error:  wrap_fun(fun, injector)
+                    for error, fun in custom_handlers.items()
+                }
 
         process_dict(subspec, injector)
 


### PR DESCRIPTION
Between 0.10 and 0.11 Flask changed the type from a list of tuples to
a dict, thereby breaking flask injector. This is likely due to the
following flask commits
https://github.com/pallets/flask/commit/eae48d97b085626c1860a900a27ff63c439e0edb
and
https://github.com/pallets/flask/commit/fd8e6b26f9ff59bc8bccd6bd251bee5838551ba8
. This fixes the bug by checking the type before wrapping the
functions.