### PR TITLE
Add support for injection into decorated methods/functions

### DIFF
--- a/flask_injector_tests.py
+++ b/flask_injector_tests.py
@@ -12,7 +12,7 @@ from flask.templating import render_template_string
 from flask.views import View
 from nose.tools import eq_
 
-from flask_injector import request, FlaskInjector
+from flask_injector import request, FlaskInjector, flask_inject
 
 
 def test_injections():
@@ -362,6 +362,21 @@ def test_noninstrospectable_hooks_dont_crash_everything():
 
     # It'd crash here
     FlaskInjector(app=app)
+
+
+def test_function_injection():
+    def configure(binder):
+        binder.bind(str, to='this is string', scope=request)
+
+    app = Flask(__name__)
+    FlaskInjector(app=app, modules=[configure])
+
+    @flask_inject
+    def func(this: str):
+        return this
+
+    with app.app_context():
+        assert func() == 'this is string'
 
 
 if injector_version >= '0.12':


### PR DESCRIPTION
This is useful for SQLAlchemy models with methods that need injected objects but couldn't normally reach them. It can be used for any functions or methods that run inside the Flask app/request context.

I'm not sure if this is useful or the right way to do this - feel free to close this if it it's not. I wanted a way of injecting into methods on a model object that needed to do something with their attributes and a dependency (for example, I have models that describe an object from an external API and provide methods to get the original object from the API, which depend on the API client configured in the injector). SQLAlchemy models create their own `__init__` methods, so injecting into the constructor wasn't a useful approach here.

```python
# api.py
class APIClient:
    pass
````

```python
# models.py
import sqlalchemy.ext.declarative
import flask_injector

@sqlalchemy.ext.declarative.as_declarative()
class Base:
    pass

class Example(Base):
    __tablename__ = 'examples'
    id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)

    @flask_injector.flask_inject
    def foo(self, bar: APIClient):
        return bar.baz()
```

```python
# app.py
import flask
import flask_injector
import api

class AppModule(injector.Module):
    def __init__(self, app: flask.Flask):
        self.app = app

    def configure(self, binder: injector.Binder) -> None:
        binder.bind(api.APIClient, to=api.APIClient(self.app), scope=injector.singleton)

app = flask.Flask(__name__)
flask_injector.FlaskInjector(app=app, modules=[AppModule(app)])
```