### PR TITLE
Don't install typing backport on recent Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
         py_modules=['flask_injector'],
         zip_safe=True,
         platforms='any',
-        install_requires=['Flask', 'injector>=0.10.0', 'typing'],
+        install_requires=['Flask', 'injector>=0.10.0', 'typing; python_version < "3.5"'],
         keywords=['Dependency Injection', 'Flask'],
         classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
I run in the same issue as https://github.com/python/typing/issues/573
 
The [proposed solution ](https://github.com/python/typing/issues/573#issuecomment-405986724) is to skip the installation of the typing library for recent python versions