### PR TITLE
Add conda package reference to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,8 @@ GitHub project page: https://github.com/alecthomas/flask_injector
 
 PyPI package page: https://pypi.org/project/Flask-Injector/
 
+Conda package page: https://anaconda.org/conda-forge/flask-injector
+
 Changelog: https://github.com/alecthomas/flask_injector/blob/master/CHANGELOG.rst
 
 Features


### PR DESCRIPTION
We recently added a conda wrapper of the PyPI package to conda-forge, installable through
```
conda install -c conda-forge flask-injector 
```

This PR simply adds a reference to that package in the README, in case you want to advertise it directly in this repository as well. If you like, I can also make one maintainer of the conda package (it's mostly a trivial job).