### PR TITLE
(wip) fix: name 'Response' is not defined

### DIFF
--- a/flask_injector/__init__.py
+++ b/flask_injector/__init__.py
@@ -62,15 +62,13 @@ def wrap_fun(fun: T, injector: Injector) -> T:
     if hasattr(fun, '__call__') and not isinstance(fun, type):
         try:
             type_hints = get_type_hints(fun)
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError, NameError):
             # Some callables aren't introspectable with get_type_hints,
             # let's assume they don't have anything to inject. The exception
             # types handled here are what I encountered so far.
             # It used to be AttributeError, then https://github.com/python/typing/pull/314
             # changed it to TypeError.
             wrap_it = False
-        except NameError:
-            wrap_it = True
         else:
             type_hints.pop('return', None)
             wrap_it = type_hints != {}


### PR DESCRIPTION
Aim to resolve #69