### PR TITLE
chore: migrate nose to pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ build/
 *.egg-info/
 .mypy_cache/
 cover/
+.coverage
 coverage.xml
+ve*/

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ ci: test lint
 
 .PHONY: test
 test:
-	nosetests -v $(SOURCES) \
-		--with-coverage --cover-package=flask_injector --cover-html --cover-branches --cover-xml
+	coverage run --source=$(SOURCES) -m pytest -v $(SOURCES)/tests.py && coverage report -m
 	PYTHONPATH=.:$(PYTHONPATH) python example.py
 
 .PHONY: lint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black;implementation_name=="cpython"
+coverage
 eventlet
 flake8
 flask
@@ -7,5 +8,5 @@ flask_restx
 flask_sqlalchemy
 injector
 mypy;implementation_name=="cpython"
-nose
+pytest
 werkzeug


### PR DESCRIPTION
Since nose is too outdated to support Python 3.10
```
  File "/Users/czhang/workspace/vendor/flask_injector/ve3.10/lib/python3.10/site-packages/nose/suite.py", line 106, in _set_tests
    if isinstance(tests, collections.Callable) and not is_suite:
AttributeError: module 'collections' has no attribute 'Callable'
```