### PR TITLE
Fix all Flask compatibility issues and make the build green

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ can `find Injector on PyPI <https://pypi.org/project/injector/>`_ and `Injector
 documentation on Read the Docs <https://injector.readthedocs.io/en/latest/>`_.
 
 `Flask-Injector` is compatible with CPython 3.7+.
-As of version post-0.13.0 it requires Injector version 0.13.2 or greater and Flask
+As of version post-0.13.0 it requires Injector version 0.20.0 or greater and Flask
 2.1.2 or greater.
 
 GitHub project page: https://github.com/alecthomas/flask_injector

--- a/flask_injector/__init__.py
+++ b/flask_injector/__init__.py
@@ -62,13 +62,15 @@ def wrap_fun(fun: T, injector: Injector) -> T:
     if hasattr(fun, '__call__') and not isinstance(fun, type):
         try:
             type_hints = get_type_hints(fun)
-        except (AttributeError, TypeError, NameError):
+        except (AttributeError, TypeError):
             # Some callables aren't introspectable with get_type_hints,
             # let's assume they don't have anything to inject. The exception
             # types handled here are what I encountered so far.
             # It used to be AttributeError, then https://github.com/python/typing/pull/314
             # changed it to TypeError.
             wrap_it = False
+        except NameError:
+            wrap_it = True
         else:
             type_hints.pop('return', None)
             wrap_it = type_hints != {}

--- a/flask_injector/__init__.py
+++ b/flask_injector/__init__.py
@@ -59,6 +59,9 @@ def wrap_fun(fun: T, injector: Injector) -> T:
     if hasattr(fun, '__bindings__'):
         return wrap_function(fun, injector)
 
+    if hasattr(fun, 'view_class'):
+        return wrap_class_based_view(fun, injector)
+
     if hasattr(fun, '__call__') and not isinstance(fun, type):
         try:
             type_hints = get_type_hints(fun)
@@ -76,9 +79,6 @@ def wrap_fun(fun: T, injector: Injector) -> T:
             wrap_it = type_hints != {}
         if wrap_it:
             return wrap_fun(inject(fun), injector)
-
-    if hasattr(fun, 'view_class'):
-        return wrap_class_based_view(fun, injector)
 
     return fun
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
         package_data={'flask_injector': ['py.typed']},
         zip_safe=True,
         platforms='any',
-        install_requires=['Flask>=2.1.2', 'injector>=0.10.0', 'typing; python_version < "3.5"'],
+        install_requires=['Flask>=2.1.2', 'injector>=0.20.0', 'typing; python_version < "3.5"'],
         keywords=['Dependency Injection', 'Flask'],
         classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Thanks to injector 0.20.0 invalid forward references in return type
annotation positions no longer break injection/detecting dependencies
(which is what GH-69 is actually about).

This PR fixes https://github.com/alecthomas/flask_injector/issues/69

This PR also effectively reverts [1] as [1] was breaking forward
reference support.

One more thing being fixed here is class-based view failures
that started happening for some reason, reordering some internal
logic handles that (we prioritize treating views as class-based views
and all is well).

[1] Fixes: 4d8bfe8ff55d ("(wip) fix: name 'Response' is not defined")