### PR TITLE
Fix compatibility with Flask 2.2.0+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ can `find Injector on PyPI <https://pypi.org/project/injector/>`_ and `Injector
 documentation on Read the Docs <https://injector.readthedocs.io/en/latest/>`_.
 
 `Flask-Injector` is compatible with CPython 3.7+.
-As of version post-0.13.0 it requires Injector version 0.20.0 or greater and Flask
-2.1.2 or greater.
+As of version 0.15.0 it requires Injector version 0.20.0 or greater and Flask
+2.2.0 or greater.
 
 GitHub project page: https://github.com/alecthomas/flask_injector
 

--- a/flask_injector/__init__.py
+++ b/flask_injector/__init__.py
@@ -317,8 +317,6 @@ class FlaskInjector:
         ):
             process_dict(container, injector)
 
-        process_list(app.before_first_request_funcs, injector)
-
         # This is to make sure that mypy sees a non-nullable variable
         # in the closures below, otherwise it'd complain that injector
         # union may not have get attribute

--- a/flask_injector/tests.py
+++ b/flask_injector/tests.py
@@ -48,11 +48,6 @@ def test_injections():
         inc()
         assert c == l
 
-    @app.before_first_request
-    def bfr(c: list):
-        inc()
-        assert c == l
-
     @app.after_request
     def ar(response_class, c: list):
         inc()
@@ -81,7 +76,7 @@ def test_injections():
     response = client.get('/view2')
     assert response.get_data(as_text=True) == '%s' % (l,)
 
-    assert counter[0] == 11
+    assert counter[0] == 10
 
 
 def test_resets():

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
         package_data={'flask_injector': ['py.typed']},
         zip_safe=True,
         platforms='any',
-        install_requires=['Flask>=2.1.2', 'injector>=0.20.0', 'typing; python_version < "3.5"'],
+        install_requires=['Flask>=2.2.0', 'injector>=0.20.0', 'typing; python_version < "3.5"'],
         keywords=['Dependency Injection', 'Flask'],
         classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fixes https://github.com/python-injector/flask_injector/issues/80

Since Flask 2.2.0 `before_first_request` is deprecated. They recommend to run setup code when creating the application instead.

So this MR simply removes the injector code around `before_first_request_funcs` because they do no longer exist. 

